### PR TITLE
Type coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "phpunit/phpunit": "^8.5.2",
         "roave/no-leaks": "^1.1",
         "squizlabs/php_codesniffer": "^3.5.4",
-        "vimeo/psalm": "^3.8"
+        "vimeo/psalm": "^3.9"
     },
     "autoload": {
         "psr-0": {
@@ -45,10 +45,7 @@
         }
     },
     "config": {
-        "sort-packages": true,
-        "platform": {
-            "php": "7.3.99"
-        }
+        "sort-packages": true
     },
     "scripts": {
         "post-install-cmd": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f56e6a1aea54549b62e97508dade64ab",
+    "content-hash": "6835531d77ec93bb38dc270f60c4efe3",
     "packages": [
         {
             "name": "clue/stream-filter",
@@ -4185,11 +4185,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3",
+        "php": "^7.4",
         "ext-json": "*"
     },
-    "platform-dev": [],
-    "platform-overrides": {
-        "php": "7.3.99"
-    }
+    "platform-dev": []
 }

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<files psalm-version="3.9.3@2e4154d76e24d1b4e59e6cc2bebef7790cb9e550">
+  <file src="src/Roave/SecurityAdvisories/Advisory.php">
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>$versionConstraints</code>
+      <code>list&lt;VersionConstraint&gt;</code>
+    </MixedReturnTypeCoercion>
+  </file>
+  <file src="src/Roave/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromFriendsOfPhp.php">
+    <MixedArgument occurrences="1">
+      <code>Yaml::parse(file_get_contents($filePath), Yaml::PARSE_EXCEPTION_ON_INVALID_TYPE)</code>
+    </MixedArgument>
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>SplFileInfo[]</code>
+    </MixedReturnTypeCoercion>
+  </file>
+  <file src="src/Roave/SecurityAdvisories/Component.php">
+    <MixedReturnTypeCoercion occurrences="2">
+      <code>$constraints</code>
+    </MixedReturnTypeCoercion>
+  </file>
+</files>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,10 +1,11 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="false"
+    totallyTyped="true"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+    errorBaseline="psalm-baseline.xml"
 >
     <projectFiles>
         <directory name="src" />

--- a/src/Roave/SecurityAdvisories/Advisory.php
+++ b/src/Roave/SecurityAdvisories/Advisory.php
@@ -45,6 +45,7 @@ final class Advisory
      */
     private function __construct(string $componentName, array $branchConstraints)
     {
+        /** @psalm-var callable(...VersionConstraint): list<VersionConstraint>|null $checkType */
         static $checkType;
 
         $checkType = $checkType ?: static function (VersionConstraint ...$versionConstraints) : array {
@@ -114,6 +115,8 @@ final class Advisory
      * @param VersionConstraint[] $versionConstraints
      *
      * @return VersionConstraint[]
+     *
+     * @psalm-return list<VersionConstraint>
      */
     private function sortVersionConstraints(array $versionConstraints) : array
     {

--- a/src/Roave/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromGithubApi.php
+++ b/src/Roave/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromGithubApi.php
@@ -122,7 +122,15 @@ final class GetAdvisoriesFromGithubApi implements GetAdvisories
         $cursor     = '';
 
         do {
-            $response        = $this->client->sendRequest($this->getRequest($cursor));
+            $response = $this->client->sendRequest($this->getRequest($cursor));
+            /** @psalm-var array{
+             * data: array{securityVulnerabilities: array{
+             *   edges: array<int, array{
+             *     cursor: string,
+             *     node: array{vulnerableVersionRange: string, package: array{name: string}}}>,
+             *   pageInfo: array{hasNextPage: bool, endCursor: string}
+             * }}} $data
+             */
             $data            = json_decode($response->getBody()->__toString(), true);
             $vulnerabilities = $data['data']['securityVulnerabilities'];
             $advisories      = array_merge($advisories, $vulnerabilities['edges']);

--- a/src/Roave/SecurityAdvisories/Version.php
+++ b/src/Roave/SecurityAdvisories/Version.php
@@ -46,11 +46,14 @@ final class Version
 
         $this->flag = Flag::build($matches['flag'] ?? '');
 
-        if (isset($matches['stability_numbers'])) {
-            $numbers = self::removeTrailingZeroes(...array_map('intval', explode('.', $matches['stability_numbers'])));
+        $this->stabilityNumbers = [];
+        if (! isset($matches['stability_numbers'])) {
+            return;
         }
 
-        $this->stabilityNumbers = $numbers ?? [];
+        $this->stabilityNumbers = self::removeTrailingZeroes(
+            ...array_map('intval', explode('.', $matches['stability_numbers']))
+        );
     }
 
     /**
@@ -66,6 +69,8 @@ final class Version
         }
 
         assert(is_array($matches));
+
+        /** @var string[] $matches */
 
         return new self($matches);
     }


### PR DESCRIPTION
This PR improves type coverage from 95.89 to 99.85%
It enable totallyTyped config and put the remaining errors in the baseline.
It also bump psalm version in composer.json to reflect what's in composer.lock

The remaining baseline errors are due to:
- Yaml input that is supposed to be array<string> but webmozart/assert still lacks psalm assertions on All* methods that could check this
- thecodingmachine/safe lacks generics for native function (for example, usort returns a list<T> with T[] as a first param)
- If I'm correct, Psalm is missing generics stubs for RecursiveDirectoryIterator and RecursiveIteratorIterator