### PR TITLE
#128 Use GitHub Actions instead of Heroku to run periodic builds of the advisories file

### DIFF
--- a/.github/workflows/scheduled_build.yml
+++ b/.github/workflows/scheduled_build.yml
@@ -17,13 +17,12 @@ jobs:
         uses: actions/cache@v2
         with:
           path: vendor
-          key: ${{ runner.os }}-node-${{ hashFiles('**/composer.lock') }}
+          key: ${{ runner.os }}-node-${{ hashFiles('/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-node-
 
       - name: Install dependencies
         id: dep-install
-        if: steps.composer-cache.outputs.cache-hit != 'true'
         run: composer install --no-progress --no-suggest
 
       - name: Set up user name and email for git

--- a/.github/workflows/scheduled_build.yml
+++ b/.github/workflows/scheduled_build.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install dependencies
         id: dep-install
         if: steps.composer-cache.outputs.cache-hit != 'true'
-        run: composer install --prefer-dist --no-progress --no-suggest
+        run: composer install --no-progress --no-suggest
 
       - name: Set up user name and email for git
         id: github-setup

--- a/.github/workflows/scheduled_build.yml
+++ b/.github/workflows/scheduled_build.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    if: (github.event_name == 'schedule' && github.repository == 'Roave/SecurityAdvisoriesBuilder') || (github.event_name != 'schedule')
+    if: github.event_name == 'schedule' && github.repository == 'Roave/SecurityAdvisoriesBuilder'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/scheduled_build.yml
+++ b/.github/workflows/scheduled_build.yml
@@ -1,0 +1,48 @@
+name: Hourly build
+
+on:
+  schedule:
+    - cron: '0 * * * *'
+
+jobs:
+  build:
+    if: (github.event_name == 'schedule' && github.repository == 'Roave/SecurityAdvisoriesBuilder') || (github.event_name != 'schedule')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-node-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Install dependencies
+        id: dep-install
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer install --prefer-dist --no-progress --no-suggest
+
+      - name: Set up user name and email for git
+        id: github-setup
+        run: |
+          git config --global user.email "$GIT_USER_EMAIL"
+          git config --global user.name "$GIT_USER_NAME"
+        env:
+          GIT_USER_EMAIL: ocramius@gmail.com
+          GIT_USER_NAME: Ocramius
+
+      - name: Build advisories
+        id: build
+        env:
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
+        run: php build-conflicts.php
+
+      - name: Push to "Roave/SecurityAdvisories"
+        run: |
+          cd build/roave-security-advisories
+          git push origin master
+

--- a/src/Roave/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromGithubApi.php
+++ b/src/Roave/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromGithubApi.php
@@ -65,7 +65,10 @@ final class GetAdvisoriesFromGithubApi implements GetAdvisories
         ClientInterface $client,
         string $token
     ) {
-        Assert::stringNotEmpty($token);
+        Assert::stringNotEmpty(
+            $token,
+            'Unable to proceed. Please make sure you have GITHUB_TOKEN environment variable set up.'
+        );
 
         $this->client = $client;
         $this->token  = $token;


### PR DESCRIPTION
Implements Github workflow that builds project hourly and then pushes to the
`Roave\SecurityAdvisories` repository.

In main repository settings it is necessary to add "secret" under name `TOKEN` which value should be a personal access tokens with `write:packages` permission. 