### PR TITLE
a bit of a clean up for regexes

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -18,6 +18,10 @@
         <exclude name="SlevomatCodingStandard.TypeHints.TypeHintDeclaration.IncorrectReturnTypeHint"/>
     </rule>
 
+    <rule ref="Generic.Files.LineLength">
+        <exclude-pattern>src/Roave/SecurityAdvisories/Matchers.php</exclude-pattern>
+    </rule>
+
     <file>build-conflicts.php</file>
     <file>public</file>
     <file>src</file>

--- a/src/Roave/SecurityAdvisories/Flag.php
+++ b/src/Roave/SecurityAdvisories/Flag.php
@@ -23,7 +23,7 @@ namespace Roave\SecurityAdvisories;
 final class Flag
 {
     /**
-     * within extent of the same version "patch" flag is of the highest priority
+     * Represent flags priority from 0 as lowest to 5 as highest
      * e.g. 1.1-alpha < 1.1-beta < 1.1-rc < 1.1-stable < 1.1 < 1.1-p
      */
     private const PRIORITY = [

--- a/src/Roave/SecurityAdvisories/Flag.php
+++ b/src/Roave/SecurityAdvisories/Flag.php
@@ -23,7 +23,7 @@ namespace Roave\SecurityAdvisories;
 final class Flag
 {
     /**
-     * within extent of same version patch flag is of the highest priority
+     * within extent of the same version "patch" flag is of the highest priority
      * e.g. 1.1-alpha < 1.1-beta < 1.1-rc < 1.1-stable < 1.1 < 1.1-p
      */
     private const PRIORITY = [

--- a/src/Roave/SecurityAdvisories/Matchers.php
+++ b/src/Roave/SecurityAdvisories/Matchers.php
@@ -20,44 +20,25 @@ declare(strict_types=1);
 
 namespace Roave\SecurityAdvisories;
 
-/**
- * @see https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
- *
- * @fixme: throw this garbage away and use existing regexp from semver.org
- */
 final class Matchers
 {
-    // pattern that matches full version only, without boundary sign
-    public const TAGGED_VERSION_MATCHER = '\s*(?<version>(?:\d+\.)*\d+)' .
-                                                '(?:-' . // dash is required for correct version
-                                                    '(?<flag>stable|beta|b|rc|alpha|a|patch|p)' .
-                                                    '[._-]?' .
-                                                    '(?<stability_numbers>(?:\d+\.)*\d+)?' .
-                                                ')?\s*';
+    /*
+     * Pattern that matches full version only, without boundary sign.
+     * Was "inspired" by semver regexp -- https://github.com/composer/semver/blob/master/src/VersionParser.php
+     * Regular expression was tailored to the needs of the package and catches:
+     * - main version, e.g. 2.1.0
+     * - stability flag, e.g. alpha, beta and etc.
+     * - stability numbers
+     */
+    public const TAGGED_VERSION_MATCHER = '\s*(?<version>(?:\d+\.)*\d+)(?:-(?<flag>stable|beta|b|rc|alpha|a|patch|p)[._-]?(?<stability_numbers>(?:\d+\.)*\d+)?)?\s*';
 
-    private const UNTAGGED_VERSION_MATCHER = '((?:\d+\.)*\d+)' .
-                                                '(?:-' .
-                                                    '(stable|beta|b|rc|alpha|a|patch|p)' .
-                                                    '[._-]?' .
-                                                    '((?:\d+\.)*\d+)?' .
-                                                ')?';
+    private const UNTAGGED_VERSION_MATCHER = '((?:\d+\.)*\d+)(?:-(stable|beta|b|rc|alpha|a|patch|p)[._-]?((?:\d+\.)*\d+)?)?';
 
-    // pattern that ensures we have a correct boundary in the right place
-    public const BOUNDARY_MATCHER = '/^\s*(?<boundary><|<=|=|>=|>)\s*' .
-                                    self::TAGGED_VERSION_MATCHER .
-                                    '\s*$/';
+    public const BOUNDARY_MATCHER = '/^\s*(?<boundary><|<=|=|>=|>)\s*' . self::TAGGED_VERSION_MATCHER . '\s*$/';
 
-    public const CLOSED_RANGE_MATCHER = '/^>(=?)\s*' .
-                                        self::UNTAGGED_VERSION_MATCHER .
-                                        '\s*,\s*<(=?)\s*' .
-                                        self::UNTAGGED_VERSION_MATCHER .
-                                        '$/';
+    public const CLOSED_RANGE_MATCHER = '/^>(=?)\s*' . self::UNTAGGED_VERSION_MATCHER . '\s*,\s*<(=?)\s*' . self::UNTAGGED_VERSION_MATCHER . '$/';
 
-    public const LEFT_OPEN_RANGE_MATCHER = '/^<(=?)\s*' .
-                                            self::UNTAGGED_VERSION_MATCHER .
-                                            '$/';
+    public const LEFT_OPEN_RANGE_MATCHER = '/^<(=?)\s*' . self::UNTAGGED_VERSION_MATCHER . '$/';
 
-    public const RIGHT_OPEN_RANGE_MATCHER = '/^>(=?)\s*' .
-                                            self::UNTAGGED_VERSION_MATCHER .
-                                            '$/';
+    public const RIGHT_OPEN_RANGE_MATCHER = '/^>(=?)\s*' . self::UNTAGGED_VERSION_MATCHER . '$/';
 }


### PR DESCRIPTION
Hello!

I recently saw that comment https://github.com/laminas/automatic-releases/issues/25#issuecomment-670851421and decided to clean class a little bit.

If I do remember correctly when `TAGGED_VERSION_MATCHER` regexp was compiled semver did not offer any regex recipes. So later on when they did offer one I though may be we could ditch the we have in favor of recommended. 

Long story short — it does not quite what package needs :thinking: 

Here is the [list](https://regex101.com/r/j4XQwo/1) mentioned in the comment with our regexp, do you think I should improve regular expression to better match that list ?
 