### PR TITLE
Add support for withdrawn advisories from Github Api

### DIFF
--- a/src/Roave/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromGithubApi.php
+++ b/src/Roave/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromGithubApi.php
@@ -114,7 +114,8 @@ final class GetAdvisoriesFromGithubApi implements GetAdvisories
      *      cursor: string,
      *      node: array{
      *          vulnerableVersionRange: string,
-     *          package: array{name: string}
+     *          package: array{name: string},
+     *          advisory: array{withdrawnAt: string|null}
      *      }
      * }>
      *

--- a/src/Roave/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromGithubApi.php
+++ b/src/Roave/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromGithubApi.php
@@ -43,6 +43,9 @@ final class GetAdvisoriesFromGithubApi implements GetAdvisories
                         package {
                             name
                         }
+                        advisory {
+                            withdrawnAt
+                        }
                     }
                 }
                 pageInfo {
@@ -79,6 +82,11 @@ final class GetAdvisoriesFromGithubApi implements GetAdvisories
         foreach ($this->getAdvisories() as $item) {
             $versions = Type\shape([0 => Type\non_empty_string(), 1 => Type\optional(Type\non_empty_string())])
                 ->assert(Str\split($item['node']['vulnerableVersionRange'], ','));
+
+            if ($item['node']['advisory']['withdrawnAt'] !== null) {
+                // Skip withdrawn advisories.
+                continue;
+            }
 
             try {
                 yield Advisory::fromArrayData(
@@ -126,6 +134,7 @@ final class GetAdvisoriesFromGithubApi implements GetAdvisories
                             'node' => Type\shape([
                                 'vulnerableVersionRange' => Type\string(),
                                 'package' => Type\shape(['name' => Type\string()]),
+                                'advisory' => Type\shape(['withdrawnAt' => Type\nullable(Type\string())]),
                             ]),
                         ])),
                         'pageInfo' => Type\shape([


### PR DESCRIPTION
See [issue #87](https://github.com/Roave/SecurityAdvisories/issues/87) at Roave/SecurityAdvisories