### PR TITLE
Fix #735 by excluding `zencart/zencart:< 1.5.5e` advisories, replaced by a dummy one

### DIFF
--- a/build-conflicts.php
+++ b/build-conflicts.php
@@ -104,7 +104,7 @@ use const PHP_BINARY;
         /**
          * @param iterable<Advisory> $advisories
          *
-         * @return Component[]
+         * @return array<non-empty-lowercase-string, Component>
          */
         static function (iterable $advisories): array {
             $indexedAdvisories = [];

--- a/psalm.xml
+++ b/psalm.xml
@@ -3,6 +3,8 @@
     allowNamedArgumentCalls="false"
     allowInternalNamedArgumentCalls="false"
     errorLevel="1"
+    findUnusedBaselineEntry="true"
+    findUnusedCode="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"

--- a/test/RoaveTest/SecurityAdvisories/VersionConstraintTest.php
+++ b/test/RoaveTest/SecurityAdvisories/VersionConstraintTest.php
@@ -653,11 +653,10 @@ final class VersionConstraintTest extends TestCase
     private function callMergeWithOverlapping(
         VersionConstraint $versionConstraint,
         VersionConstraint $other,
-    ): VersionConstraint {
+    ): void {
         $mergeWithOverlappingReflection = new ReflectionMethod($versionConstraint, 'mergeWithOverlapping');
 
-        return Type\instance_of(VersionConstraint::class)
-            ->assert($mergeWithOverlappingReflection->invoke($versionConstraint, $other));
+        $mergeWithOverlappingReflection->invoke($versionConstraint, $other);
     }
 
     /** @psalm-return non-empty-list<array{non-empty-string}> */


### PR DESCRIPTION
Ref: https://github.com/composer/packagist/issues/1385
Ref: https://github.com/Roave/SecurityAdvisoriesBuilder/issues/735
Ref: https://packagist.org/packages/zencart/
Ref: https://packagist.org/packages/zencart/zencart
Ref: https://github.com/zencart/zencart/issues/5870
Ref: https://github.com/advisories/GHSA-c9r9-3h38-r7vj
Ref: https://github.com/advisories/GHSA-38f9-4vhq-9cr8
Ref: https://github.com/advisories/GHSA-wxxx-2x6v-979f

Zencart uses a weird versioning scheme: `(\d+)\.(\d+)\.(\d+)(a|b|c|d|e|f)?`

This scheme doesn't seem to be composer-compliant, and leads to all sorts of complexity,
so we're replacing the latest zencart advisory with a "safe to use" one, while
original maintainers are notified about the potential versioning scheme problem.

Fixes #735