### PR TITLE
temporarily install a Composer dev version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "ext-json": "*",
         "ext-pcre": "*",
         "azjezz/psl": "^2.8.0",
-        "composer/composer": "^2.6.5",
+        "composer/composer": "^2.6.6@dev",
         "composer/semver": "^3.4.0",
         "monolog/monolog": "^3.5.0",
         "nyholm/psr7": "^1.8.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9ff5ae90ce481999866f2bad635357f6",
+    "content-hash": "afafa29e89234d1ff471e368b997fa39",
     "packages": [
         {
             "name": "azjezz/psl",
@@ -297,16 +297,16 @@
         },
         {
             "name": "composer/composer",
-            "version": "2.6.5",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "4b0fe89db9e65b1e64df633a992e70a7a215ab33"
+                "reference": "da83d29d8ac634783bc70b0f3b7847bae3e081d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/4b0fe89db9e65b1e64df633a992e70a7a215ab33",
-                "reference": "4b0fe89db9e65b1e64df633a992e70a7a215ab33",
+                "url": "https://api.github.com/repos/composer/composer/zipball/da83d29d8ac634783bc70b0f3b7847bae3e081d9",
+                "reference": "da83d29d8ac634783bc70b0f3b7847bae3e081d9",
                 "shasum": ""
             },
             "require": {
@@ -345,13 +345,14 @@
                 "ext-zip": "Enabling the zip extension allows you to unzip archives",
                 "ext-zlib": "Allow gzip compression of HTTP requests"
             },
+            "default-branch": true,
             "bin": [
                 "bin/composer"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.6-dev"
+                    "dev-main": "2.7-dev"
                 },
                 "phpstan": {
                     "includes": [
@@ -391,7 +392,7 @@
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
                 "security": "https://github.com/composer/composer/security/policy",
-                "source": "https://github.com/composer/composer/tree/2.6.5"
+                "source": "https://github.com/composer/composer/tree/main"
             },
             "funding": [
                 {
@@ -407,7 +408,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-10-06T08:11:52+00:00"
+            "time": "2023-11-08T11:02:00+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -6581,7 +6582,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "composer/composer": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
A fix for Composer forbidding to install the incompatible version 7 of symfony/console has already been merged, but is not released yet.