### PR TITLE
Ignore bogus advisories

### DIFF
--- a/src/Roave/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromGithubApi.php
+++ b/src/Roave/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromGithubApi.php
@@ -37,6 +37,10 @@ use UnexpectedValueException;
 
 final class GetAdvisoriesFromGithubApi implements GetAdvisories
 {
+    private const IGNORED_ADVISORIES = [
+        'GHSA-7q22-x757-cmgc', // @see https://phpc.social/@wouterj/113588554019692959
+        'GHSA-cg28-v4wq-whv5' // @see https://phpc.social/@wouterj/113588554019692959
+    ];
     private const GRAPHQL_QUERY = 'query {
             securityVulnerabilities(ecosystem: COMPOSER, first: 100 %s) {
                 edges {
@@ -84,6 +88,10 @@ final class GetAdvisoriesFromGithubApi implements GetAdvisories
 
             if ($item['node']['advisory']['withdrawnAt'] !== null) {
                 // Skip withdrawn advisories.
+                continue;
+            }
+            if (in_array($item['node']['advisory']['ghsaId'], self::IGNORED_ADVISORIES, true)) {
+                // Skip ignored advisories.
                 continue;
             }
 

--- a/src/Roave/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromGithubApi.php
+++ b/src/Roave/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromGithubApi.php
@@ -35,13 +35,15 @@ use Roave\SecurityAdvisories\Exception\InvalidPackageName;
 use SensitiveParameter;
 use UnexpectedValueException;
 
+use function in_array;
+
 final class GetAdvisoriesFromGithubApi implements GetAdvisories
 {
     private const IGNORED_ADVISORIES = [
         'GHSA-7q22-x757-cmgc', // @see https://phpc.social/@wouterj/113588554019692959
-        'GHSA-cg28-v4wq-whv5' // @see https://phpc.social/@wouterj/113588554019692959
+        'GHSA-cg28-v4wq-whv5', // @see https://phpc.social/@wouterj/113588554019692959
     ];
-    private const GRAPHQL_QUERY = 'query {
+    private const GRAPHQL_QUERY      = 'query {
             securityVulnerabilities(ecosystem: COMPOSER, first: 100 %s) {
                 edges {
                     cursor
@@ -90,6 +92,7 @@ final class GetAdvisoriesFromGithubApi implements GetAdvisories
                 // Skip withdrawn advisories.
                 continue;
             }
+
             if (in_array($item['node']['advisory']['ghsaId'], self::IGNORED_ADVISORIES, true)) {
                 // Skip ignored advisories.
                 continue;

--- a/test/RoaveTest/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromGithubApiTest.php
+++ b/test/RoaveTest/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromGithubApiTest.php
@@ -341,9 +341,7 @@ class GetAdvisoriesFromGithubApiTest extends TestCase
         ], Vec\Values($advisories()));
     }
 
-    /**
-     * @dataProvider correctResponseWithIgnoredAdvisories
-     */
+    /** @dataProvider correctResponseWithIgnoredAdvisories */
     public function testWillSkipIgnoredAdvisories(ResponseInterface ...$responses): void
     {
         $client = $this->createMock(Client::class);


### PR DESCRIPTION
By design, anyone can register a CVE, and sometimes these are false positive. Like the one in cURL https://curl.se/docs/CVE-2023-52071.html

Sadly, it's almost impossible to discard a CVE. This PR aims to ignore a list of advisories in `roave/security-advisories`, in a similar way packagist does  https://github.com/composer/packagist/pull/1493 and how this repository already patches some entries https://github.com/Roave/SecurityAdvisoriesBuilder/blob/d0f7f8fa8cabfeeb8947ecdbff14cc58f2834190/src/Roave/SecurityAdvisories/Rule/RuleProviderFactory.php#L43

side note: This PR does not use the `RuleProviderFactory` because I believe "matching only the package/version" could be an issue: If one day another CVE (a real one) is open with the same `original constraint` the rule will patch it. As a result, the output will miss the original constraint