### PR TITLE
Ignore simplesamlphp/simplesamlphp GHSA-j5g2-q29x-cw3h

### DIFF
--- a/src/Roave/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromGithubApi.php
+++ b/src/Roave/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromGithubApi.php
@@ -42,6 +42,8 @@ final class GetAdvisoriesFromGithubApi implements GetAdvisories
     private const IGNORED_ADVISORIES = [
         'GHSA-7q22-x757-cmgc', // @see https://phpc.social/@wouterj/113588554019692959
         'GHSA-cg28-v4wq-whv5', // @see https://phpc.social/@wouterj/113588554019692959
+        // @see https://github.com/github/advisory-database/pull/5047, advisory is for the tarball version only
+        'GHSA-j5g2-q29x-cw3h',
     ];
     private const GRAPHQL_QUERY      = 'query {
             securityVulnerabilities(ecosystem: COMPOSER, first: 100 %s) {


### PR DESCRIPTION
Advisory GHSA-j5g2-q29x-cw3h applies only to the tarball version of SimpleSAMLphp and not the composer package, because the vulnerability is in the simplesamlphp/saml2 dependency (which has its own advisory under GHSA-pxm4-r5ph-q2m2). The advisory was issued because many people install SimpleSAMLphp from tarball which ships with a composer.lock pointing to the vulnerable saml2 version.

See also: https://github.com/github/advisory-database/pull/5047