### PR TITLE
Ignore bogus nette/database GHSA/CVE

### DIFF
--- a/src/Roave/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromGithubApi.php
+++ b/src/Roave/SecurityAdvisories/AdvisorySources/GetAdvisoriesFromGithubApi.php
@@ -44,6 +44,7 @@ final class GetAdvisoriesFromGithubApi implements GetAdvisories
         'GHSA-cg28-v4wq-whv5', // @see https://phpc.social/@wouterj/113588554019692959
         // @see https://github.com/github/advisory-database/pull/5047, advisory is for the tarball version only
         'GHSA-j5g2-q29x-cw3h',
+        'GHSA-f626-677r-j5vq', // @see https://github.com/nette/database/issues/314
     ];
     private const GRAPHQL_QUERY      = 'query {
             securityVulnerabilities(ecosystem: COMPOSER, first: 100 %s) {


### PR DESCRIPTION
Ignore https://github.com/advisories/GHSA-f626-677r-j5vq which is, per https://github.com/nette/database/issues/314, a documented and intended feature. The PoC repo and the article from the GHSA are now gone and the CVE itself (CVE-2024-55586) is disputed.